### PR TITLE
Mismatch in Volume Definition

### DIFF
--- a/src/Console/Commands/SailInstallCommand.php
+++ b/src/Console/Commands/SailInstallCommand.php
@@ -86,7 +86,7 @@ class SailInstallCommand extends Command
             ->filter(function ($service) {
                 return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
             })->map(function ($service) {
-                return "    sail{$service}:\n        driver: local";
+                return "    sail-{$service}:\n        driver: local";
             })->whenNotEmpty(function ($collection) {
                 return $collection->prepend('volumes:');
             })->implode("\n");


### PR DESCRIPTION
Fixes errors like this:

ERROR: Named volume "sail-redis:/data:rw" is used in service "redis" but no declaration was found in the volumes section.
ERROR: Named volume "sail-redis:/data:rw" is used in service "redis" but no declaration was found in the volumes section.
ERROR: Named volume "sail-redis:/data:rw" is used in service "redis" but no declaration was found in the volumes section.